### PR TITLE
Vecpar implementation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,7 +90,7 @@ register_model(acc ACC ACCStream.cpp)
 register_model(raja USE_RAJA RAJAStream.cpp)
 register_model(tbb TBB TBBStream.cpp)
 register_model(thrust THRUST ThrustStream.cu) # Thrust uses cu, even for rocThrust
-
+register_model(vecpar VECPAR VecparStream.cpp)
 
 set(USAGE ON CACHE BOOL "Whether to print all custom flags for the selected model")
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -49,6 +49,8 @@
 #include "SYCLStream2020.h"
 #elif defined(OMP)
 #include "OMPStream.h"
+#elif defined(VECPAR)
+#include "VecparStream.hpp"
 #endif
 
 // Default size of 2^25
@@ -298,6 +300,9 @@ void run()
   // Use the OpenMP implementation
   stream = new OMPStream<T>(ARRAY_SIZE, deviceIndex);
 
+#elif defined(VECPAR)
+  // Use vecpar implementation
+  stream = new VecparStream<T>(ARRAY_SIZE, deviceIndex);
 #endif
 
   stream->init_arrays(startA, startB, startC);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -58,7 +58,7 @@ int ARRAY_SIZE = 33554432;
 unsigned int num_times = 100;
 unsigned int deviceIndex = 0;
 bool use_float = false;
-bool output_as_csv = false;
+bool output_as_csv = true;
 bool mibibytes = false;
 std::string csv_separator = ",";
 

--- a/src/vecpar/VecparStream.cpp
+++ b/src/vecpar/VecparStream.cpp
@@ -1,0 +1,275 @@
+#include "VecparStream.hpp"
+
+template <class T>
+VecparStream<T>::VecparStream(const int ARRAY_SIZE, int device)
+{
+    array_size = ARRAY_SIZE;
+
+    // Allocate on the host
+    this->a = new vecmem::vector<T>(array_size, &memoryResource);
+    this->b = new vecmem::vector<T>(array_size, &memoryResource);
+    this->c = new vecmem::vector<T>(array_size, &memoryResource);
+}
+
+template <class T>
+VecparStream<T>::~VecparStream()
+{
+    free(a);
+    free(b);
+    free(c);
+}
+
+template <class T>
+void VecparStream<T>::init_arrays(T initA, T initB, T initC)
+{
+    int array_size = this->array_size;
+
+    for (int i = 0; i < array_size; i++)
+    {
+        a->at(i) = initA;
+        b->at(i) = initB;
+        c->at(i) = initC;
+    }
+
+#if defined(VECPAR_GPU) && defined(DEFAULT)
+    d_a = copy_tool.to(vecmem::get_data(*a),
+                  dev_mem,
+                  vecmem::copy::type::host_to_device);
+    d_b = copy_tool.to(vecmem::get_data(*b),
+                  dev_mem,
+                  vecmem::copy::type::host_to_device);
+    d_c = copy_tool.to(vecmem::get_data(*c),
+                  dev_mem,
+                  vecmem::copy::type::host_to_device);
+#endif
+}
+
+template <class T>
+void VecparStream<T>::read_arrays(std::vector<T>& h_a, std::vector<T>& h_b, std::vector<T>& h_c)
+{
+
+#if defined(VECPAR_GPU) && defined(DEFAULT)
+    copy_tool(d_a, *a, vecmem::copy::type::device_to_host);
+    copy_tool(d_b, *b, vecmem::copy::type::device_to_host);
+    copy_tool(d_c, *c, vecmem::copy::type::device_to_host);
+#endif
+
+    for (int i = 0; i < array_size; i++)
+    {
+        h_a[i] = a->at(i);
+        h_b[i] = b->at(i);
+        h_c[i] = c->at(i);
+    }
+}
+
+template <class T>
+void VecparStream<T>::copy()
+{
+#if defined(SINGLE_SOURCE) // gpu+managed, cpu
+    vecpar_copy<T> algorithm;
+    vecpar::parallel_algorithm(algorithm, memoryResource, *c, *a);
+#else
+    #ifdef VECPAR_GPU
+        vecpar::cuda::parallel_map(
+                array_size,
+                [=] __device__ (int idx,
+                vecmem::data::vector_view<T> &c_view,
+                vecmem::data::vector_view<T> &a_view) {
+            vecmem::device_vector<T> dc(c_view);
+            vecmem::device_vector<T> da(a_view);
+            dc[idx] = da[idx] ;
+        },
+        vecmem::get_data(d_c),
+        vecmem::get_data(d_a));
+    #else // lambda
+        vecpar::omp::parallel_map(array_size,
+                              [&] (int idx)  { c->at(idx) = a->at(idx);});
+    #endif
+#endif
+}
+
+template <class T>
+void VecparStream<T>::mul()
+{
+    const T scalar = startScalar;
+#if defined(SINGLE_SOURCE)
+    vecpar_mul<T> algorithm;
+    vecpar::parallel_algorithm(algorithm, memoryResource, *b, *c, scalar);
+#else
+    #ifdef VECPAR_GPU
+        vecpar::cuda::parallel_map(
+                array_size,
+                [=] __device__ (int idx,
+                vecmem::data::vector_view<T> &b_view,
+                vecmem::data::vector_view<T> &c_view,
+                T dscalar) {
+            vecmem::device_vector<T> db(b_view);
+            vecmem::device_vector<T> dc(c_view);
+            db[idx] = dscalar * dc[idx] ;
+           },
+        vecmem::get_data(d_b),
+        vecmem::get_data(d_c),
+        scalar);
+    #else
+        vecpar::omp::parallel_map(array_size,
+                              [&] (int idx)  { b->at(idx) = scalar * c->at(idx);});
+    #endif
+#endif
+}
+
+template <class T>
+void VecparStream<T>::add()
+{
+#if defined(SINGLE_SOURCE)
+    vecpar_add<T> algorithm;
+    vecpar::parallel_algorithm(algorithm, memoryResource, *c, *a, *b);
+#else //defined (DEFAULT)
+    #ifdef VECPAR_GPU
+        vecpar::cuda::parallel_map(
+                array_size,
+                [=] __device__ (int idx,
+                vecmem::data::vector_view<T> &a_view,
+                vecmem::data::vector_view<T> &b_view,
+                vecmem::data::vector_view<T> &c_view) {
+            vecmem::device_vector<T> da(a_view);
+            vecmem::device_vector<T> db(b_view);
+            vecmem::device_vector<T> dc(c_view);
+            dc[idx] = da[idx] + db[idx] ;
+            },
+        vecmem::get_data(d_a),
+        vecmem::get_data(d_b),
+        vecmem::get_data(d_c));
+    #else
+        vecpar::omp::parallel_map(array_size,
+                              [&] (int idx)  { c->at(idx) = a->at(idx) + b->at(idx);});
+    #endif
+#endif
+}
+
+template <class T>
+void VecparStream<T>::triad()
+{
+    const T scalar = startScalar;
+    int array_size = this->array_size;
+
+    #if defined(SINGLE_SOURCE)
+        vecpar_triad<T> algorithm;
+        vecpar::parallel_algorithm(algorithm, memoryResource, *a, *b, *c, scalar);
+    #else //defined (DEFAULT)
+        #if defined (VECPAR_GPU)
+            vecpar::cuda::parallel_map(
+                    array_size,
+                    [=] __device__ (int idx,
+                                    vecmem::data::vector_view<T> &a_view,
+                                    vecmem::data::vector_view<T> &b_view,
+                                    vecmem::data::vector_view<T> &c_view,
+                                    T dscalar) {
+                vecmem::device_vector<T> da(a_view);
+                vecmem::device_vector<T> db(b_view);
+                vecmem::device_vector<T> dc(c_view);
+                da[idx] = db[idx] + dscalar * dc[idx];
+            },
+            vecmem::get_data(d_a),
+            vecmem::get_data(d_b),
+            vecmem::get_data(d_c),
+            scalar);
+        #else
+            vecpar::omp::parallel_map(array_size,
+                                      [&] (int idx) {
+                        a->at(idx) = b->at(idx) + scalar * c->at(idx); });
+        #endif
+    #endif
+}
+
+template <class T>
+void VecparStream<T>::nstream()
+{
+    const T scalar = startScalar;
+
+    #if defined(SINGLE_SOURCE)
+        vecpar_nstream<T> algorithm;
+        vecpar::parallel_algorithm(algorithm, memoryResource, *a, *b, *c, scalar);
+    #else
+    #ifdef VECPAR_GPU
+        vecpar::cuda::parallel_map(
+                array_size,
+                [=] __device__ (int idx,
+                vecmem::data::vector_view<T> &a_view,
+                vecmem::data::vector_view<T> &b_view,
+                vecmem::data::vector_view<T> &c_view,
+                T dscalar) {
+            vecmem::device_vector<T> da(a_view);
+            vecmem::device_vector<T> db(b_view);
+            vecmem::device_vector<T> dc(c_view);
+             da[idx] += db[idx] + dscalar * dc[idx];
+           },
+        vecmem::get_data(d_a),
+        vecmem::get_data(d_b),
+        vecmem::get_data(d_c),
+        scalar);
+    #else
+        vecpar::omp::parallel_map(array_size,
+                              [&] (int idx)  { a->at(idx) = b->at(idx) + scalar * c->at(idx);});
+    #endif
+#endif
+}
+
+template <class T>
+T VecparStream<T>::dot()
+{
+    T* sum = new T();
+    *sum = 0.0;
+#if defined(SINGLE_SOURCE)
+    vecpar_dot<T> algorithm;
+    *sum = vecpar::parallel_algorithm(algorithm, memoryResource, *a, *b);
+#else
+    #ifdef VECPAR_GPU
+        T* dsum;
+        cudaMalloc(&dsum, sizeof(T));
+        vecpar::cuda::offload_reduce(array_size,
+                                     [=](int* lock, int size, T* dsum,
+                                             vecmem::data::vector_view<T> a_view,
+                                             vecmem::data::vector_view<T> b_view) {
+                                         vecmem::device_vector<T> da(a_view);
+                                         vecmem::device_vector<T> db(b_view);
+                                         size_t idx = blockIdx.x * blockDim.x + threadIdx.x;
+                                         if (idx >= size)
+                                             return;
+                                         atomicAdd(dsum, (da[idx]*db[idx]));
+            }, array_size, dsum,
+            vecmem::get_data(d_a),
+            vecmem::get_data(d_b));
+        cudaMemcpy(sum, dsum, sizeof(T), cudaMemcpyDeviceToHost);
+        cudaFree(dsum);
+    #else
+        vecmem::vector<T> result(array_size, &memoryResource);
+        vecpar::omp::parallel_map(array_size,
+                                  [&] (int idx) { result.at(idx) = a->at(idx) * b->at(idx); });
+        vecpar::omp::parallel_reduce(array_size, sum,
+                              [&] (T* sum, T& value)  { *sum += value; }, result);
+    #endif
+#endif
+    return *sum;
+}
+
+void listDevices(void)
+{
+#ifdef VECPAR_GPU
+    std::cout << "Not implemented yet" << std::endl;
+#else
+    std::cout << "0: CPU" << std::endl;
+#endif
+}
+
+std::string getDeviceName(const int)
+{
+    return std::string("Device name unavailable");
+}
+
+std::string getDeviceDriver(const int)
+{
+    return std::string("Device driver unavailable");
+}
+
+template class VecparStream<float>;
+template class VecparStream<double>;

--- a/src/vecpar/VecparStream.cpp
+++ b/src/vecpar/VecparStream.cpp
@@ -96,13 +96,12 @@ void VecparStream<T>::copy()
 {
 #if defined(SINGLE_SOURCE) // gpu+managed
     vecpar_copy<T> algorithm;
-#if defined(NATIVE)  // omp + cuda
-     vecpar::parallel_algorithm(algorithm, memoryResource, *c, *a);
+    #if defined(NATIVE)  // omp + cuda
+        vecpar::parallel_algorithm(algorithm, memoryResource, *c, *a);
+    #else
+        vecpar::ompt::parallel_algorithm(algorithm, memoryResource, *c, *a);
+    #endif
 #else
-    vecpar::ompt::parallel_algorithm(algorithm, memoryResource, *c, *a);
-#endif
-#else
-    #ifdef VECPAR_GPU
         vecpar::cuda::parallel_map(
                 array_size,
                 [=] __device__ (int idx,
@@ -114,10 +113,6 @@ void VecparStream<T>::copy()
         },
         vecmem::get_data(d_c),
         vecmem::get_data(d_a));
-    #else // lambda
-        vecpar::omp::parallel_map(array_size,
-                              [&] (int idx)  { c->at(idx) = a->at(idx);});
-    #endif
 #endif
 }
 
@@ -127,13 +122,12 @@ void VecparStream<T>::mul()
     const T scalar = startScalar;
 #if defined(SINGLE_SOURCE)
     vecpar_mul<T> algorithm;
-#if defined(NATIVE)  // omp + cuda
-    vecpar::parallel_algorithm(algorithm, memoryResource, *b, *c, scalar);
+    #if defined(NATIVE)  // omp + cuda
+        vecpar::parallel_algorithm(algorithm, memoryResource, *b, *c, scalar);
+    #else
+        vecpar::ompt::parallel_algorithm(algorithm, memoryResource, *b, *c, scalar);
+    #endif
 #else
-    vecpar::ompt::parallel_algorithm(algorithm, memoryResource, *b, *c, scalar);
-#endif
-#else
-    #ifdef VECPAR_GPU
         vecpar::cuda::parallel_map(
                 array_size,
                 [=] __device__ (int idx,
@@ -147,10 +141,6 @@ void VecparStream<T>::mul()
         vecmem::get_data(d_b),
         vecmem::get_data(d_c),
         scalar);
-    #else
-        vecpar::omp::parallel_map(array_size,
-                              [&] (int idx)  { b->at(idx) = scalar * c->at(idx);});
-    #endif
 #endif
 }
 
@@ -159,13 +149,12 @@ void VecparStream<T>::add()
 {
 #if defined(SINGLE_SOURCE)
     vecpar_add<T> algorithm;
-#if defined(NATIVE)  // omp + cuda
-    vecpar::parallel_algorithm(algorithm, memoryResource, *c, *a, *b);
-#else
-    vecpar::ompt::parallel_algorithm(algorithm, memoryResource, *c, *a, *b);
-#endif
+    #if defined(NATIVE)  // omp + cuda
+        vecpar::parallel_algorithm(algorithm, memoryResource, *c, *a, *b);
+    #else
+        vecpar::ompt::parallel_algorithm(algorithm, memoryResource, *c, *a, *b);
+    #endif
 #else //defined (DEFAULT)
-    #ifdef VECPAR_GPU
         vecpar::cuda::parallel_map(
                 array_size,
                 [=] __device__ (int idx,
@@ -180,10 +169,6 @@ void VecparStream<T>::add()
         vecmem::get_data(d_a),
         vecmem::get_data(d_b),
         vecmem::get_data(d_c));
-    #else
-        vecpar::omp::parallel_map(array_size,
-                              [&] (int idx)  { c->at(idx) = a->at(idx) + b->at(idx);});
-    #endif
 #endif
 }
 
@@ -195,13 +180,12 @@ void VecparStream<T>::triad()
 
     #if defined(SINGLE_SOURCE)
         vecpar_triad<T> algorithm;
-#if defined(NATIVE)  // omp + cuda
-    vecpar::parallel_algorithm(algorithm, memoryResource, *a, *b, *c, scalar);
-#else
-    vecpar::ompt::parallel_algorithm(algorithm, memoryResource, *a, *b, *c, scalar);
-#endif
+        #if defined(NATIVE)  // omp + cuda
+            vecpar::parallel_algorithm(algorithm, memoryResource, *a, *b, *c, scalar);
+        #else
+            vecpar::ompt::parallel_algorithm(algorithm, memoryResource, *a, *b, *c, scalar);
+        #endif
     #else //defined (DEFAULT)
-        #if defined (VECPAR_GPU)
             vecpar::cuda::parallel_map(
                     array_size,
                     [=] __device__ (int idx,
@@ -218,11 +202,6 @@ void VecparStream<T>::triad()
             vecmem::get_data(d_b),
             vecmem::get_data(d_c),
             scalar);
-        #else
-            vecpar::omp::parallel_map(array_size,
-                                      [&] (int idx) {
-                        a->at(idx) = b->at(idx) + scalar * c->at(idx); });
-        #endif
     #endif
 }
 
@@ -233,13 +212,12 @@ void VecparStream<T>::nstream()
 
     #if defined(SINGLE_SOURCE)
         vecpar_nstream<T> algorithm;
-#if defined(NATIVE)  // omp + cuda
-    vecpar::parallel_algorithm(algorithm, memoryResource, *a, *b, *c, scalar);
-#else
-    vecpar::ompt::parallel_algorithm(algorithm, memoryResource, *a, *b, *c, scalar);
-#endif
+        #if defined(NATIVE)  // omp + cuda
+            vecpar::parallel_algorithm(algorithm, memoryResource, *a, *b, *c, scalar);
+        #else
+            vecpar::ompt::parallel_algorithm(algorithm, memoryResource, *a, *b, *c, scalar);
+        #endif
     #else
-    #ifdef VECPAR_GPU
         vecpar::cuda::parallel_map(
                 array_size,
                 [=] __device__ (int idx,
@@ -256,11 +234,7 @@ void VecparStream<T>::nstream()
         vecmem::get_data(d_b),
         vecmem::get_data(d_c),
         scalar);
-    #else
-        vecpar::omp::parallel_map(array_size,
-                              [&] (int idx)  { a->at(idx) = b->at(idx) + scalar * c->at(idx);});
-    #endif
-#endif
+ #endif
 }
 
 template <class T>
@@ -270,13 +244,12 @@ T VecparStream<T>::dot()
     *sum = 0.0;
 #if defined(SINGLE_SOURCE)
     vecpar_dot<T> algorithm;
-#if defined(NATIVE)  // omp + cuda
-    *sum = vecpar::parallel_algorithm(algorithm, memoryResource, *a, *b);
+    #if defined(NATIVE)  // omp + cuda
+        *sum = vecpar::parallel_algorithm(algorithm, memoryResource, *a, *b);
+    #else
+        *sum = vecpar::ompt::parallel_algorithm(algorithm, memoryResource, *a, *b);
+    #endif
 #else
-    *sum = vecpar::ompt::parallel_algorithm(algorithm, memoryResource, *a, *b);
-#endif
-#else
-    #ifdef VECPAR_GPU
         T* dsum;
         cudaMalloc(&dsum, sizeof(T));
         vecpar::cuda::offload_reduce(array_size,
@@ -294,13 +267,6 @@ T VecparStream<T>::dot()
             vecmem::get_data(d_b));
         cudaMemcpy(sum, dsum, sizeof(T), cudaMemcpyDeviceToHost);
         cudaFree(dsum);
-    #else
-        vecmem::vector<T> result(array_size, &memoryResource);
-        vecpar::omp::parallel_map(array_size,
-                                  [&] (int idx) { result.at(idx) = a->at(idx) * b->at(idx); });
-        vecpar::omp::parallel_reduce(array_size, sum,
-                              [&] (T* sum, T& value)  { *sum += value; }, result);
-    #endif
 #endif
     return *sum;
 }

--- a/src/vecpar/VecparStream.hpp
+++ b/src/vecpar/VecparStream.hpp
@@ -1,0 +1,170 @@
+#pragma once
+
+#include <iostream>
+
+#include <vecmem/containers/vector.hpp>
+#include <vecmem/memory/host_memory_resource.hpp>
+
+#include "Stream.h"
+
+#ifdef VECPAR_GPU
+#include "cuda.h"
+#include <vecmem/memory/cuda/managed_memory_resource.hpp>
+#include <vecmem/memory/cuda/device_memory_resource.hpp>
+#include <vecmem/containers/data/vector_buffer.hpp>
+#include <vecmem/utils/cuda/copy.hpp>
+#include <vecpar/cuda/cuda_parallelization.hpp>
+#endif
+
+#include <vecpar/all/main.hpp>
+
+#if defined(VECPAR_GPU) && defined(MANAGED)
+    #define IMPLEMENTATION_STRING "vecpar_gpu_single_source_managed_memory"
+    #define SINGLE_SOURCE "1"
+#elif defined(VECPAR_GPU) && defined(DEFAULT)
+    #define IMPLEMENTATION_STRING "vecpar_gpu_host_device_memory"
+#else
+//##elif defined(MANAGED)
+    #define IMPLEMENTATION_STRING "vecpar_cpu_single_source"
+    #define SINGLE_SOURCE "1"
+//#else
+  //  #define IMPLEMENTATION_STRING "vecpar_cpu_host_memory"
+#endif
+
+
+template <class T>
+class VecparStream : public Stream<T>
+{
+protected:
+    // Size of arrays
+    int array_size;
+
+    // Host side pointers or managed memory
+    vecmem::vector<T> *a;
+    vecmem::vector<T> *b;
+    vecmem::vector<T> *c;
+
+#if defined(VECPAR_GPU) && defined(MANAGED)
+    vecmem::cuda::managed_memory_resource memoryResource;
+#elif defined(VECPAR_GPU) && defined(DEFAULT)
+    vecmem::host_memory_resource memoryResource;
+    vecmem::cuda::device_memory_resource dev_mem;
+    vecmem::cuda::copy copy_tool;
+
+    vecmem::data::vector_buffer<T> d_a;
+    vecmem::data::vector_buffer<T> d_b;
+    vecmem::data::vector_buffer<T> d_c;
+#else
+    vecmem::host_memory_resource memoryResource;
+#endif
+
+public:
+    VecparStream(const int, int);
+    ~VecparStream();
+
+    virtual void copy() override;
+    virtual void add() override;
+    virtual void mul() override;
+    virtual void triad() override;
+    virtual void nstream() override;
+    virtual T dot() override;
+
+    virtual void init_arrays(T initA, T initB, T initC) override;
+    virtual void read_arrays(std::vector<T>& a, std::vector<T>& b, std::vector<T>& c) override;
+};
+
+/// if SHARED MEMORY is set, then vecpar single source code can be used;
+/// define one algorithm per function
+#ifdef MANAGED
+    template <class T>
+    struct vecpar_triad :
+        public vecpar::algorithm::parallelizable_mmap<
+            vecpar::collection::Three,
+            vecmem::vector<T>, // a
+            vecmem::vector<T>, // b
+            vecmem::vector<T>, // c
+            const T // scalar
+            > {
+        TARGET T& map(T& a_i, const T& b_i, const T& c_i, const T scalar) const {
+            a_i = b_i + scalar * c_i;
+            return a_i;
+        }
+    };
+
+template <class T>
+struct vecpar_add :
+        public vecpar::algorithm::parallelizable_mmap<
+                vecpar::collection::Three,
+                vecmem::vector<T>, // c
+                vecmem::vector<T>, // a
+                vecmem::vector<T>> // b
+                {
+    TARGET T& map(T& c_i, const T& a_i, const T& b_i) const {
+        c_i = a_i + b_i ;
+        return c_i;
+    }
+};
+
+template <class T>
+struct vecpar_mul:
+        public vecpar::algorithm::parallelizable_mmap<
+                vecpar::collection::Two,
+                vecmem::vector<T>, // b
+                vecmem::vector<T>, // c
+                const T > //  scalar
+            {
+    TARGET T& map(T& b_i, const T& c_i, const T scalar) const {
+        b_i = scalar * c_i ;
+        return b_i;
+    }
+};
+
+template <class T>
+struct vecpar_copy:
+        public vecpar::algorithm::parallelizable_mmap<
+                vecpar::collection::Two,
+                vecmem::vector<T>, // c
+                vecmem::vector<T>> // a
+{
+    TARGET T& map(T& c_i, const T& a_i) const {
+        c_i = a_i;
+        return c_i;
+    }
+};
+
+template <class T>
+struct vecpar_dot:
+        public vecpar::algorithm::parallelizable_map_reduce<
+                vecpar::collection::Two,
+                T, // reduction result
+                vecmem::vector<T>, // map result
+                vecmem::vector<T>, // a
+                vecmem::vector<T>> // b
+{
+    TARGET T& map(T& result, T& a_i, const T& b_i) const {
+        result = a_i * b_i;
+        return result;
+    }
+
+    TARGET T* reduce(T* result, T& crt) const {
+        *result += crt;
+        return result;
+    }
+};
+
+template <class T>
+struct vecpar_nstream : public vecpar::algorithm::parallelizable_mmap<
+        vecpar::collection::Three,
+        vecmem::vector<T>, // a
+        vecmem::vector<T>, // b
+        vecmem::vector<T>, // c
+        const T> // scalar
+{
+    TARGET T& map(T& a_i, const T& b_i, const T& c_i, const T scalar) const {
+        a_i += b_i + scalar * c_i;
+        return a_i;
+    }
+
+};
+#endif
+

--- a/src/vecpar/VecparStream.hpp
+++ b/src/vecpar/VecparStream.hpp
@@ -26,8 +26,10 @@
 //backend = NATIVE/ompt, memory = default/managed, offload=0/1
 #if defined(NATIVE) and defined(DEFAULT) and defined(VECPAR_GPU)
     #define IMPLEMENTATION_STRING "vecpar_cuda_hostdevice"
+    #undef SINGLE_SOURCE
 #elif defined(NATIVE) and defined(DEFAULT) and !defined(VECPAR_GPU)
     #define IMPLEMENTATION_STRING "vecpar_omp_hostmemory"
+    #define SINGLE_SOURCE 1
 #elif defined(NATIVE) and defined(MANAGED) and defined(VECPAR_GPU)
     #define IMPLEMENTATION_STRING "vecpar_cuda_singlesource_managedmemory"
     #define SINGLE_SOURCE 1
@@ -92,10 +94,7 @@ public:
     virtual void read_arrays(std::vector<T>& a, std::vector<T>& b, std::vector<T>& c) override;
 };
 
-
-/// if SHARED MEMORY is set, then vecpar single source code can be used;
-/// define one algorithm per function
-//#ifdef MANAGED
+/// define vecpar algorithms
     template <class T>
     struct vecpar_triad :
         public vecpar::algorithm::parallelizable_mmap<
@@ -186,5 +185,5 @@ struct vecpar_nstream : public vecpar::algorithm::parallelizable_mmap<
     }
 
 };
-#endif
+
 

--- a/src/vecpar/model.cmake
+++ b/src/vecpar/model.cmake
@@ -1,0 +1,147 @@
+
+register_flag_optional(CMAKE_CXX_COMPILER
+        "Any CXX compiler that supports OpenMP as per CMake detection (and offloading if enabled with `OFFLOAD`)"
+        "c++")
+
+register_flag_optional(ARCH
+        "This overrides CMake's CMAKE_SYSTEM_PROCESSOR detection which uses (uname -p), this is mainly for use with
+         specialised accelerators only and not to be confused with offload which is is mutually exclusive with this.
+         Supported values are:
+          - NEC"
+        "")
+
+register_flag_optional(OFFLOAD
+        "Whether to use OpenMP offload, the format is <VENDOR:ARCH?>|ON|OFF.
+        We support a small set of known offload flags for clang, gcc, and icpx.
+        However, as offload support is rapidly evolving, we recommend you directly supply them via OFFLOAD_FLAGS.
+        For example:
+          * OFFLOAD=NVIDIA:sm_60
+          * OFFLOAD=ON OFFLOAD_FLAGS=..."
+        OFF)
+
+register_flag_optional(OFFLOAD_FLAGS
+        "If OFFLOAD is enabled, this *overrides* the default offload flags"
+        "")
+
+register_flag_optional(OFFLOAD_APPEND_LINK_FLAG
+        "If enabled, this appends all resolved offload flags (OFFLOAD=<vendor:arch> or directly from OFFLOAD_FLAGS) to the link flags.
+        This is required for most offload implementations so that offload libraries can linked correctly."
+        ON)
+
+#register_flag_optional(VECPAR_BACKEND
+ #       "Valid values:
+  #          * VECPAR_BACKEND=OFF (default)
+   #         * VECPAR_BACKEND=CUDA
+    #        * VECPAR_BACKEND=OMPT" OFF)
+
+register_flag_optional(MEM "Device memory mode:
+        DEFAULT   - allocate host and device memory pointers.
+        MANAGED   - use CUDA Managed Memory"
+        "DEFAULT")
+
+set(VECPAR_FLAGS_CLANG -fopenmp)
+set(VECPAR_FLAGS_OFFLOAD_CLANG_NVIDIA --language=cuda)
+#set(VECPAR_BACKEND "CUDA")
+
+macro(setup)
+
+    set(CMAKE_CXX_STANDARD 20)
+    set(LINKER_LANGUAGE CXX)
+    register_definitions(${MEM})
+
+    string(TOUPPER ${CMAKE_CXX_COMPILER_ID} COMPILER)
+    find_package(vecpar REQUIRED 0.0.3)
+
+    find_package(OpenMP QUIET)
+    #find_package(vecmem QUIET)
+
+
+    if (("${OFFLOAD}" STREQUAL OFF) OR (NOT DEFINED OFFLOAD))
+        # no offload
+
+        # CPU OpenMP backend can be built by either GCC or Clang
+        register_link_library(OpenMP::OpenMP_CXX)
+
+        list(APPEND VECPAR_FLAGS -fopenmp)
+        # resolve the CPU specific flags
+   #     set(VECPAR_FLAGS -fopenmp)
+    #    set(VECPAR_LINK_FLAGS -fopenmp)
+  #      register_append_compiler_and_arch_specific_cxx_flags(
+   #             VECPAR_FLAGS_CPU
+    #            ${COMPILER}
+     #           ${ARCH}
+     #   )
+
+      #  register_append_compiler_and_arch_specific_link_flags(
+       #         VECPAR_LINK_FLAGS_CPU
+        #        ${COMPILER}
+         #       ${ARCH}
+        #)
+
+    elseif ("${OFFLOAD}" STREQUAL ON)
+        #  offload but with custom flags
+        find_package(CUDAToolkit QUIET)
+        register_definitions(VECPAR_GPU)
+        separate_arguments(OFFLOAD_FLAGS)
+        set(VECPAR_FLAGS ${OFFLOAD_FLAGS})
+        register_link_library(CUDA::cudart)
+        register_link_library(vecmem::cuda)
+        register_link_library(vecpar::all)
+    elseif ((DEFINED OFFLOAD) AND OFFLOAD_FLAGS)
+        # offload but OFFLOAD_FLAGS overrides
+        find_package(CUDAToolkit QUIET)
+        register_definitions(VECPAR_GPU)
+        separate_arguments(OFFLOAD_FLAGS)
+        list(VECPAR_FLAGS APPEND  ${OFFLOAD_FLAGS})
+        register_link_library(CUDA::cudart)
+        register_link_library(vecmem::cuda)
+        register_link_library(vecpar::all)
+    else ()
+        find_package(CUDAToolkit QUIET)
+        register_definitions(VECPAR_GPU)
+     #   list(APPEND VECPAR_FLAGS "-x cuda")
+
+        # handle the vendor:arch value
+        string(REPLACE ":" ";" OFFLOAD_TUPLE "${OFFLOAD}")
+
+        list(LENGTH OFFLOAD_TUPLE LEN)
+        if (LEN EQUAL 1)
+            #  offload with <vendor> tuple
+            list(GET OFFLOAD_TUPLE 0 OFFLOAD_VENDOR)
+            # append VECPAR_FLAGS_OFFLOAD_<vendor> if  exists
+            list(APPEND VECPAR_FLAGS ${VECPAR_FLAGS_OFFLOAD_${OFFLOAD_VENDOR}})
+
+        elseif (LEN EQUAL 2)
+            #  offload with <vendor:arch> tuple
+            list(GET OFFLOAD_TUPLE 0 OFFLOAD_VENDOR)
+            list(GET OFFLOAD_TUPLE 1 OFFLOAD_ARCH)
+
+            # append VECPAR_FLAGS_OFFLOAD_<compiler>_<vendor> if exists
+            list(APPEND VECPAR_FLAGS ${VECPAR_FLAGS_OFFLOAD_${COMPILER}_${OFFLOAD_VENDOR}})
+            # append offload arch if VECPAR_FLAGS_OFFLOAD_<compiler>_ARCH_FLAG if exists
+            if (DEFINED VECPAR_FLAGS_OFFLOAD_${COMPILER}_ARCH_FLAG)
+                list(APPEND VECPAR_FLAGS
+                        ${VECPAR_FLAGS_OFFLOAD_${COMPILER}_ARCH_FLAG}${OFFLOAD_ARCH})
+            endif ()
+            list(APPEND VECPAR_FLAGS --offload-arch=${OFFLOAD_ARCH})
+        else ()
+            message(FATAL_ERROR "Unrecognised OFFLOAD format: `${OFFLOAD}`, consider directly using OFFLOAD_FLAGS")
+        endif ()
+
+        register_link_library(CUDA::cudart)
+        register_link_library(vecmem::cuda)
+    endif ()
+
+
+    register_link_library(vecpar::all)
+    register_link_library(vecmem::core)
+
+    # propagate flags to linker so that it links with the offload stuff as well
+    register_append_cxx_flags(ANY ${VECPAR_FLAGS})
+#    if (OFFLOAD_APPEND_LINK_FLAG)
+ #       register_append_link_flags(${VECPAR_FLAGS})
+  #  endif ()
+
+endmacro()
+
+

--- a/src/vecpar/model.cmake
+++ b/src/vecpar/model.cmake
@@ -46,7 +46,7 @@ if ("${VECPAR_BACKEND}" STREQUAL "OMPT")
             -foffload=nvptx-none -DCOMPILE_FOR_DEVICE)
     set(VECPAR_FLAGS_OFFLOAD_GNU_AMD
             -foffload=amdgcn-amdhsa -DCOMPILE_FOR_DEVICE)
-    set(VECPAR_FLAGS_OFFLOAD_CLANG_NVIDIA -fopenmp -fopenmp-targets=nvptx64 -gline-tables-only -DCOMPILE_FOR_DEVICE)
+    set(VECPAR_FLAGS_OFFLOAD_CLANG_NVIDIA -fopenmp -fopenmp-targets=nvptx64 -DCOMPILE_FOR_DEVICE)
     set(VECPAR_FLAGS_OFFLOAD_CLANG_AMD
             -fopenmp=libomp -fopenmp-targets=amdgcn-amd-amdhsa -Xopenmp-target=amdgcn-amd-amdhsa -DCOMPILE_FOR_DEVICE)
 else()


### PR DESCRIPTION
Provide implementations for scenarios

- [x] run in parallel using vecpar offloading lambda (CUDA and OpenMP)
- [x] run in parallel using single-source algorithms (CUDA and OpenMP)
- [x] ability to choose memory resource for GPU (managed-memory AND host-device memory)
- [ ] ability to choose different offloading backend (CUDA vs OpenMP target) -- requires vecpar::map/mmap/map_reduce with 1,2,3 collections
- [ ] scripts for automatic testing (update/adapt existing)
- [ ] BUG - dot kernel fails for 100 repetitions (works for 50); I assume some chunks on memory are not released